### PR TITLE
Fix functional tests on Github Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,6 @@ jobs:
   test:
     name: Test Blueprints
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - name: Check out code

--- a/blueprint/keycloak.hcl
+++ b/blueprint/keycloak.hcl
@@ -30,24 +30,6 @@ ingress "keycloak" {
   }
 }
 
-# Expose old ingress model for remote exec as shipyard 
-# ingress runs on the local host and when using GitHub Actions 
-# this address is not accessible
-k8s_ingress "keycloak" {
-  cluster = "k8s_cluster.k8s"
-  service = "keycloak"
-
-  network {
-    name = "network.local"
-  }
-
-  port {
-    local  = 8080
-    remote = 8080
-    host   = 18080
-  }
-}
-
 exec_remote "keycloak_config" {
   depends_on = ["k8s_config.keycloak"]
 
@@ -68,7 +50,7 @@ exec_remote "keycloak_config" {
 
   env {
     key   = "KEYCLOAK_URL"
-    value = "keycloak.k8s-ingress.shipyard.run:8080"
+    value = "${shipyard_ip()}:8080"
   }
 
 }

--- a/blueprint/keycloak.hcl
+++ b/blueprint/keycloak.hcl
@@ -30,6 +30,24 @@ ingress "keycloak" {
   }
 }
 
+# Expose old ingress model for remote exec as shipyard 
+# ingress runs on the local host and when using GitHub Actions 
+# this address is not accessible
+k8s_ingress "keycloak" {
+  cluster = "k8s_cluster.k8s"
+  service = "keycloak"
+
+  network {
+    name = "network.local"
+  }
+
+  port {
+    local  = 8080
+    remote = 8080
+    host   = 18080
+  }
+}
+
 exec_remote "keycloak_config" {
   depends_on = ["k8s_config.keycloak"]
 
@@ -50,7 +68,7 @@ exec_remote "keycloak_config" {
 
   env {
     key   = "KEYCLOAK_URL"
-    value = "host.docker.internal:8080"
+    value = "keycloak.k8s-ingress.shipyard.run:8080"
   }
 
 }

--- a/blueprint/keycloak.hcl
+++ b/blueprint/keycloak.hcl
@@ -50,7 +50,7 @@ exec_remote "keycloak_config" {
 
   env {
     key   = "KEYCLOAK_URL"
-    value = "${shipyard_ip()}:8080"
+    value = "host.docker.internal:8080"
   }
 
 }

--- a/blueprint/keycloak/scripts/keycloak-config.sh
+++ b/blueprint/keycloak/scripts/keycloak-config.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #KEYCLOAK_URL=http://keycloak.ingress.shipyard.run:8080
-KEYCLOAK_URL=host.docker.internal:8080
+#KEYCLOAK_URL=host.docker.internal:8080
 
 apk update && apk --no-progress add jq
 


### PR DESCRIPTION
This PR removes the hardcoded address for keycloak from the scripts as host.docker.internal does not work in Gihub actions docker.